### PR TITLE
Update header UI

### DIFF
--- a/src/layouts/partials/components/nav.html
+++ b/src/layouts/partials/components/nav.html
@@ -1,13 +1,13 @@
-<nav class="w-60 flex items-center">
+<nav class="w-50 flex items-center">
   <ul class="w-100 list ma0 pa0 flex flex-end justify-between items-center tr">
     {{ $currentPage := . }}
     {{ range first 3 .Site.Menus.main }}
-    <li class="w-30 pv2 tr">
+    <li class="pv2 tc">
       <a href="{{ .URL }}" class="{{ if $currentPage.IsMenuCurrent "main" . }}active{{ end }} no-underline pa1 ttc body2 body-l lh-copy" title="{{ .Name }}">{{ .Name }}</a>
     </li>
     {{ end }}
     
-    <li class="w-30 pv2 tr">
+    <li class="pv2 tr">
     <div class="flex flex-auto justify-center items-center"></div>
     <label class="relative w2 h2 ml3 dib bn" for="menu-switch" id="menu-toggle">
       {{ partial "icons/svg.html" (dict "svg" "toggle" "stroke" "currentcolor") }}

--- a/src/layouts/partials/components/nav.html
+++ b/src/layouts/partials/components/nav.html
@@ -1,13 +1,17 @@
-<nav class="w-70 flex items-center">
-  <ul class="w-100 list ma0 pa0 flex flex-end justify-between tr">
+<nav class="w-60 flex items-center">
+  <ul class="w-100 list ma0 pa0 flex flex-end justify-between items-center tr">
     {{ $currentPage := . }}
-    {{ range first 2 .Site.Menus.main }}
+    {{ range first 3 .Site.Menus.main }}
     <li class="w-30 pv2 tr">
       <a href="{{ .URL }}" class="{{ if $currentPage.IsMenuCurrent "main" . }}active{{ end }} no-underline pa1 ttc body2 body-l lh-copy" title="{{ .Name }}">{{ .Name }}</a>
     </li>
     {{ end }}
+    
     <li class="w-30 pv2 tr">
-      <a href="https://id.resonate.coop" class="no-underline pa1 ttc body2 body-l lh-copy" title="Join us">Join Us</a>
+    <div class="flex flex-auto justify-center items-center"></div>
+    <label class="relative w2 h2 ml3 dib bn" for="menu-switch" id="menu-toggle">
+      {{ partial "icons/svg.html" (dict "svg" "toggle" "stroke" "currentcolor") }}
+    </label>
     </li>
   </ul>
 </nav>

--- a/src/layouts/partials/components/navbar.html
+++ b/src/layouts/partials/components/navbar.html
@@ -1,16 +1,15 @@
-<header class="z-max flex w-100 ph3-ns overflow-hidden ph2 items-center">
-  <a href="/" id="nav-logo" class="icon--lg dib no-underline pv1 border-box flex items-center">
-    {{ partial "icons/svg.html" (dict "svg" "logo" "color" "fill-current-color") }}
-  </a>
-  {{ if eq .Section ""}}
-  <span class="w4 dn border-box flex-ns items-center overflow-hidden pv1 pl2" style="height: 58px;">
-    {{ partial "icons/svg.html" (dict "svg" "logotype" "color" "fill-current-color") }}
-  </span>
-  {{ end }}
+<header class="z-max flex w-100 ph3-ns overflow-hidden ph2 justify-between items-center">
+  <a href="/" class="flex items-center">
+    <span id="nav-logo" class="icon--lg dib no-underline pv1 border-box flex items-center">
+      {{ partial "icons/svg.html" (dict "svg" "logo" "color" "fill-current-color") }}
+    </span>
 
-  <div class="flex flex-auto justify-center items-center"></div>
+    {{ if eq .Section ""}}
+    <span class="w4 dn border-box flex-ns items-center overflow-hidden pv1 pl2" style="height: 58px;">
+      {{ partial "icons/svg.html" (dict "svg" "logotype" "color" "fill-current-color") }}
+    </span>
+    {{ end }}
+  </a>
+
   {{ partial "components/nav" . }}
-  <label class="relative w2 h2 ml3 dib bn" for="menu-switch" id="menu-toggle">
-    {{ partial "icons/svg.html" (dict "svg" "toggle" "stroke" "currentcolor") }}
-  </label>
 </header>


### PR DESCRIPTION
This PR will:
- Put the + button in the `<nav>`, aligning its spacing with the nav items
- Slightly decrease spacing between nav items
- Add the resonate logo text to the icon's `<a>` tag

I realize now that having the text clickable is kinda pointless since it links to the root and also only shows up in the root route. I just felt it was weird that only a specific part of the logo was clickable on the home page.

The header now looks like this:

![image](https://user-images.githubusercontent.com/11844126/98419992-11e03e00-203b-11eb-839c-704a895a5e97.png)
