### PR TITLE
fix: add tabindex for menu toggle

### DIFF
--- a/src/layouts/partials/components/nav-main.html
+++ b/src/layouts/partials/components/nav-main.html
@@ -15,7 +15,7 @@
       </a>
     </li>
     <li id="learn">
-      <button title="Open learn menu" class="bg-transparent near-black near-black--light near-white--dark bn dropdown-toggle pa3">
+      <button title="Open learn menu" tabindex="0" class="bg-transparent near-black near-black--light near-white--dark bn dropdown-toggle pa3">
         <div class="flex justify-center items-center">
           <span>{{ T "learn" }}</span> 
           <div class="ph2">


### PR DESCRIPTION


This is a test fix for on mobile iOS Safari, where it looks like :focus-within needs this extra feature to work

https://stackoverflow.com/questions/66477748/focus-within-works-on-android-browser-but-not-ios
