### PR TITLE
Link to the the working Instagram profile

### DIFF
--- a/src/config/_default/params.yaml
+++ b/src/config/_default/params.yaml
@@ -9,7 +9,7 @@ social:
   url: https://www.facebook.com/resonatecoop
 - name: ig
   title: Instagram
-  url: https://www.instagram.com/resonate_coop/
+  url: https://ig.me/u/resonate.coop
 rss:
 - name: RSS
   title: Blog RSS feed


### PR DESCRIPTION
- Updated the Instagram link with the current username, resonate.coop, replacing the old username, resonate_coop.
- Modified the Instagram link to use the shortened version.